### PR TITLE
Don't use param $fields as $query when $query is empty.

### DIFF
--- a/src/League/Monga/Collection.php
+++ b/src/League/Monga/Collection.php
@@ -301,8 +301,8 @@ class Collection
 
         // Prepare the find arguments
         $arguments = [];
-        empty($query) || $arguments[] = $query;
-        empty($fields) || $arguments[] = $fields;
+        $arguments[] = $query;
+        $arguments[] = $fields;
 
         // Wrap the find function so it is callable
         $function = [


### PR DESCRIPTION
Fixes #23