### PR TITLE
Query builders usable by Collection methods

### DIFF
--- a/tests/CollectionTests.php
+++ b/tests/CollectionTests.php
@@ -151,6 +151,19 @@ class CollectionTests extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->collection->count());
     }
 
+    public function testRemoveWithQuery()
+    {
+        $where = new League\Monga\Query\Remove();
+
+        $where->where('name', 'Frank');
+
+        $this->collection->getCollection()->insert(['name' => 'Frank']);
+        $this->assertEquals(1, $this->collection->count());
+        $result = $this->collection->remove($where);
+        $this->assertTrue($result);
+        $this->assertEquals(0, $this->collection->count());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */
@@ -240,6 +253,14 @@ class CollectionTests extends PHPUnit_Framework_TestCase
     public function testFind()
     {
         $result = $this->collection->find();
+        $this->assertInstanceOf('League\Monga\Cursor', $result);
+    }
+
+    public function testFindWithQuery()
+    {
+        $query = new League\Monga\Query\Find();
+        $result = $this->collection->find($query);
+        
         $this->assertInstanceOf('League\Monga\Cursor', $result);
     }
 
@@ -368,6 +389,16 @@ class CollectionTests extends PHPUnit_Framework_TestCase
                 ->increment('viewcount', 2);
         });
 
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateWithQuery()
+    {
+        $query = new League\Monga\Query\Update();
+
+        $query->set('name', 'changed');
+
+        $result = $this->collection->update($query);
         $this->assertTrue($result);
     }
 


### PR DESCRIPTION
This PR allows `Query\Builder` instances to be passed to various `Collection` methods:

* `find` allows a `Query\Find` instance to be passed as the first parameter
* `remove` allows a `Query\Remove` instance to be passed as the first parameter
* `update` allows a `Query\Update` instance to be passed as the first parameter

P.S. Apologies if this PR "sucks" in any way, this is actually breaking my PR virginity. Feedback, both positive and/or negative, is greatly appreciated.