### PR TITLE
Add *WhereGeoWithin methods (Mongo > 2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `monga` will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- *WhereGeoWithin (and+or) $geoWithin (Mongo > 2.4)
+- PHPUnit test cover for *WhereGeoWithin
+
+### Deprecated
+
+- *whereWithin, deprected after Mongo 2.4, use $geoWithin instead
+
 ## 1.2.4 - 2015-02-29
 
 - Updated license year.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "devitek/monga",
+    "name": "league/monga",
     "type": "library",
     "description": "MongoDB Abstraction Layer",
     "keywords": ["MongoDB"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "league/monga",
+    "name": "devitek/monga",
     "type": "library",
     "description": "MongoDB Abstraction Layer",
     "keywords": ["MongoDB"],

--- a/src/League/Monga/Query/Where.php
+++ b/src/League/Monga/Query/Where.php
@@ -974,7 +974,7 @@ class Where extends Builder
      */
     public function orWhereWithin($field, $shape, $options = [])
     {
-        return $this->formatWhere('$or', $field, ['$geoWithin' => $shape] + $options);
+        return $this->formatWhere('$or', $field, ['$within' => $shape] + $options);
     }
 
     /**
@@ -1016,7 +1016,7 @@ class Where extends Builder
      */
     public function orWhereGeoWithin($field, $shape, $options = [])
     {
-        return $this->formatWhere('$or', $field, ['$within' => $shape] + $options);
+        return $this->formatWhere('$or', $field, ['$geoWithin' => $shape] + $options);
     }
 
     /**

--- a/src/League/Monga/Query/Where.php
+++ b/src/League/Monga/Query/Where.php
@@ -932,6 +932,8 @@ class Where extends Builder
     /**
      * Appends a and-where-within statement
      *
+     * @deprecated since Mongo 2.4, use whereGeoWithin
+     *
      * @param string $field   _id field
      * @param string $shape   shape
      * @param array  $options options
@@ -946,6 +948,8 @@ class Where extends Builder
     /**
      * Appends a and-where-within statement
      *
+     * @deprecated since Mongo 2.4, use whereGeoWithin
+     *
      * @param string $field   _id field
      * @param string $shape   shape
      * @param array  $options options
@@ -958,7 +962,9 @@ class Where extends Builder
     }
 
     /**
-     * Appends a and-where-near statement
+     * Appends a and-where-within statement
+     *
+     * @deprecated since Mongo 2.4, use whereGeoWithin
      *
      * @param string $field   _id field
      * @param string $shape   shape
@@ -968,6 +974,48 @@ class Where extends Builder
      */
     public function orWhereWithin($field, $shape, $options = [])
     {
+        return $this->formatWhere('$or', $field, ['$geoWithin' => $shape] + $options);
+    }
+
+    /**
+     * Appends a and-where-geoWithin statement
+     *
+     * @param string $field   _id field
+     * @param string $shape   shape
+     * @param array  $options options
+     *
+     * @return object $this
+     */
+    public function whereGeoWithin($field, $shape, $options = [])
+    {
+        return $this->formatWhere('$and', $field, ['$geoWithin' => $shape] + $options);
+    }
+
+    /**
+     * Appends a and-where-geoWithin statement
+     *
+     * @param string $field   _id field
+     * @param string $shape   shape
+     * @param array  $options options
+     *
+     * @return object $this
+     */
+    public function andWhereGeoWithin($field, $shape, $options = [])
+    {
+        return call_user_func_array([$this, 'whereGeoWithin'], [$field, $shape, $options]);
+    }
+
+    /**
+     * Appends a and-where-geoWithin statement
+     *
+     * @param string $field   _id field
+     * @param string $shape   shape
+     * @param array  $options options
+     *
+     * @return object $this
+     */
+    public function orWhereGeoWithin($field, $shape, $options = [])
+    {
         return $this->formatWhere('$or', $field, ['$within' => $shape] + $options);
     }
 
@@ -975,7 +1023,7 @@ class Where extends Builder
      * Appends a and-nor-where-clause
      *
      * @param array|closure $clause nor where clause
-     * @param integer       $type   chain type
+     * @param string        $type   chain type
      *
      * @return object $this
      */

--- a/tests/QueryWhereTests.php
+++ b/tests/QueryWhereTests.php
@@ -1049,6 +1049,23 @@ class QueryWhereTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->getProperty('where'));
     }
 
+    public function testWhereGeoWithin()
+    {
+        $this->query->whereGeoWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5]);
+
+        $expected = [
+            '$or' => [
+                [
+                    '$and' => [
+                        ['location' => ['$within' => ['$box' => [[0,0],[10,10]]], '$maxDistance' => 5]],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->getProperty('where'));
+    }
+
     public function testAndWhereWithin()
     {
         $this->query->andWhereWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5]);
@@ -1066,10 +1083,50 @@ class QueryWhereTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->getProperty('where'));
     }
 
+    public function testAndWhereGeoWithin()
+    {
+        $this->query->andWhereGeoWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5]);
+
+        $expected = [
+            '$or' => [
+                [
+                    '$and' => [
+                        ['location' => ['$within' => ['$box' => [[0,0],[10,10]]], '$maxDistance' => 5]],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->getProperty('where'));
+    }
+
     public function testOrWhereWithin()
     {
         $this->query->whereWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5])
-            ->orWhereWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5]);
+                    ->orWhereWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5]);
+
+        $expected = [
+            '$or' => [
+                [
+                    '$and' => [
+                        ['location' => ['$within' => ['$box' => [[0,0],[10,10]]], '$maxDistance' => 5]],
+                    ],
+                ],
+                [
+                    '$and' => [
+                        ['location' => ['$within' => ['$box' => [[0,0],[10,10]]], '$maxDistance' => 5]],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->getProperty('where'));
+    }
+
+    public function testOrWhereGeoWithin()
+    {
+        $this->query->whereGeoWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5])
+                    ->orWhereGeoWithin('location', ['$box' => [[0, 0], [10, 10]]], ['$maxDistance' => 5]);
 
         $expected = [
             '$or' => [


### PR DESCRIPTION
This PR adds support to "$geoWithin" keyword instead of "$within" which was deprecated after Mongo 2.4.