### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "mockery/mockery": "0.9.*",
         "squizlabs/php_codesniffer": "2.3.*",
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-0": { "League\\Monga": "src/" }

--- a/tests/CollectionTests.php
+++ b/tests/CollectionTests.php
@@ -4,8 +4,9 @@ use League\Monga;
 use League\Monga\Collection;
 use League\Monga\Database;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class CollectionTests extends PHPUnit_Framework_TestCase
+class CollectionTests extends TestCase
 {
     protected $database;
     protected $connection;
@@ -260,7 +261,7 @@ class CollectionTests extends PHPUnit_Framework_TestCase
     {
         $query = new League\Monga\Query\Find();
         $result = $this->collection->find($query);
-        
+
         $this->assertInstanceOf('League\Monga\Cursor', $result);
     }
 

--- a/tests/ConnectionTests.php
+++ b/tests/ConnectionTests.php
@@ -1,8 +1,9 @@
 <?php
 
 use League\Monga\Connection;
+use PHPUnit\Framework\TestCase;
 
-class ConnectionTests extends PHPUnit_Framework_TestCase
+class ConnectionTests extends TestCase
 {
     protected $connection;
 

--- a/tests/CursorTests.php
+++ b/tests/CursorTests.php
@@ -1,8 +1,9 @@
 <?php
 
 use League\Monga;
+use PHPUnit\Framework\TestCase;
 
-class CursorTests extends PHPUnit_Framework_TestCase
+class CursorTests extends TestCase
 {
     public function testCursor()
     {

--- a/tests/DatabaseTests.php
+++ b/tests/DatabaseTests.php
@@ -3,8 +3,9 @@
 use League\Monga;
 use League\Monga\Connection;
 use League\Monga\Database;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseTests extends PHPUnit_Framework_TestCase
+class DatabaseTests extends TestCase
 {
     protected $database;
 

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 class FileMock
 {
     protected $return = true;
@@ -19,7 +21,7 @@ class FileMock
     }
 }
 
-class FilesystemTests extends PHPUnit_Framework_TestCase
+class FilesystemTests extends TestCase
 {
     public function testStore()
     {

--- a/tests/MongaTests.php
+++ b/tests/MongaTests.php
@@ -1,8 +1,9 @@
 <?php
 
 use League\Monga;
+use PHPUnit\Framework\TestCase;
 
-class MongaTests extends PHPUnit_Framework_TestCase
+class MongaTests extends TestCase
 {
     public function testMongaId()
     {

--- a/tests/QueryAggregateTests.php
+++ b/tests/QueryAggregateTests.php
@@ -1,8 +1,9 @@
 <?php
 
 use League\Monga\Query\Aggregation as Agr;
+use PHPUnit\Framework\TestCase;
 
-class QueryAggregateTests extends PHPUnit_Framework_TestCase
+class QueryAggregateTests extends TestCase
 {
     public function testProject()
     {

--- a/tests/QueryBuilderTests.php
+++ b/tests/QueryBuilderTests.php
@@ -1,10 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 class BuilderMock extends League\Monga\Query\Builder
 {
 }
 
-class QueryBuilderTests extends PHPUnit_Framework_TestCase
+class QueryBuilderTests extends TestCase
 {
     protected $builder;
 

--- a/tests/QueryFindTests.php
+++ b/tests/QueryFindTests.php
@@ -1,6 +1,8 @@
 <?php
 
-class QueryFindTests extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class QueryFindTests extends TestCase
 {
     protected $find;
 

--- a/tests/QueryIndexesTests.php
+++ b/tests/QueryIndexesTests.php
@@ -2,8 +2,9 @@
 
 use League\Monga\Query\Indexes as i;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class QueryIndexesTests extends PHPUnit_Framework_TestCase
+class QueryIndexesTests extends TestCase
 {
     protected $indexes;
 

--- a/tests/QueryRemoveTests.php
+++ b/tests/QueryRemoveTests.php
@@ -1,6 +1,8 @@
 <?php
 
-class QueryRemoveTests extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class QueryRemoveTests extends TestCase
 {
     protected $remove;
 

--- a/tests/QueryUpdateTests.php
+++ b/tests/QueryUpdateTests.php
@@ -1,6 +1,8 @@
 <?php
 
-class QueryUpdateTests extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class QueryUpdateTests extends TestCase
 {
     protected $update;
 

--- a/tests/QueryWhereTests.php
+++ b/tests/QueryWhereTests.php
@@ -1,7 +1,8 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 
-class QueryWhereTests extends PHPUnit_Framework_TestCase
+class QueryWhereTests extends TestCase
 {
     protected $query;
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.